### PR TITLE
Multiarch: Add s390x support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ FROM alpine:3.9
 
 WORKDIR /root/
 
-COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check
-COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-darwin
-COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-armhf
-COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-arm64
-
+COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check .
+COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-darwin .
+COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-armhf .
+COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-arm64 .
+COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-s390x .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: linux darwin armhf arm64
+all: linux darwin armhf arm64 s390x
 
 .PHONY: linux
 linux:
@@ -16,3 +16,8 @@ armhf:
 .PHONY: arm64
 arm64:
 	GOOS=linux GOARCH=arm64 go build -o license-check-arm64 --ldflags "-s -w" -a -installsuffix cgo
+
+.PHONY: s390x
+s390x:
+	GOOS=linux GOARCH=s390x go build -o license-check-s390x --ldflags "-s -w" -a -installsuffix cgo
+

--- a/get.sh
+++ b/get.sh
@@ -20,6 +20,11 @@ suffix="-darwin"
     suffix="-armhf"
     ;;
     esac
+    case $arch in
+    "s390x")
+    suffix="s390x"
+    ;;
+    esac
 ;;
 esac
 


### PR DESCRIPTION
Enable licence check to be used in various architectures like s390x(zOS)

**Fixed issue in Dockerfile**
```
root@durgadas:~/code/license-check# docker build -t license .
Sending build context to Docker daemon  10.27MB
Step 1/13 : FROM golang:1.10.4-alpine as builder
1.10.4-alpine: Pulling from library/golang
4fe2ade4980c: Pull complete
2e793f0ebe8a: Pull complete
77995fba1918: Pull complete
4495499e856d: Pull complete
0ff8f8e34aa6: Pull complete
Digest: sha256:55ff778715a4f37ef0f2f7568752c696906f55602be0e052cbe147becb65dca3
Status: Downloaded newer image for golang:1.10.4-alpine
 ---> bd36346540f3
Step 2/13 : RUN apk add --no-cache make
 ---> Running in c99acc1afeda
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
(1/1) Installing make (4.2.1-r2)
Executing busybox-1.28.4-r1.trigger
OK: 5 MiB in 15 packages
Removing intermediate container c99acc1afeda
 ---> edc5d1a595fa
Step 3/13 : WORKDIR /go/src/github.com/teamserverless/license-check
 ---> Running in 80deb8c3d435
Removing intermediate container 80deb8c3d435
 ---> 74da23304e78
Step 4/13 : COPY . .
 ---> 6468f6fef787
Step 5/13 : RUN make
 ---> Running in 1bfa40a5e7dc
GOOS=linux go build -o license-check --ldflags "-s -w" -a -installsuffix cgo
GOOS=darwin go build -o license-check-darwin --ldflags "-s -w" -a -installsuffix cgo
GOOS=linux GOARCH=arm GOARM=6 go build -o license-check-armhf --ldflags "-s -w" -a -installsuffix cgo
GOOS=linux GOARCH=arm64 go build -o license-check-arm64 --ldflags "-s -w" -a -installsuffix cgo
GOOS=linux GOARCH=s390x go build -o license-check-s390x --ldflags "-s -w" -a -installsuffix cgo
 ---> db85c412a916
Step 6/13 : FROM alpine:3.9
3.9: Pulling from library/alpine
e7c96db7181b: Pull complete
Digest: sha256:769fddc7cc2f0a1c35abb2f91432e8beecf83916c421420e6a6da9f8975464b6
Status: Downloaded newer image for alpine:3.9
 ---> 055936d39205
Step 7/13 : WORKDIR /root/
 ---> Running in 61af13103ceb
Removing intermediate container 61af13103ceb
 ---> cf78d9453a2e
Step 8/13 : COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check .
 ---> c7fe0e23b09f
Step 9/13 : COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-darwin .
 ---> 277a160b3be4
Step 10/13 : COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-armhf .
 ---> 6c5c3425eabf
Step 11/13 : COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-arm64 .
 ---> 0581635e3142
Step 12/13 : COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-s390x .
 ---> d07dcc99b435
Successfully built d07dcc99b435
Successfully tagged license:latest
root@durgadas:~/code/license-check# docker run --rm license ls
license-check
license-check-arm64
license-check-armhf
license-check-darwin
license-check-s390x
```

**Makefile**
```
root@durgadas:~/code/license-check# make all
GOOS=linux go build -o license-check --ldflags "-s -w" -a -installsuffix cgo
GOOS=darwin go build -o license-check-darwin --ldflags "-s -w" -a -installsuffix cgo
GOOS=linux GOARCH=arm GOARM=6 go build -o license-check-armhf --ldflags "-s -w" -a -installsuffix cgo
GOOS=linux GOARCH=arm64 go build -o license-check-arm64 --ldflags "-s -w" -a -installsuffix cgo
GOOS=linux GOARCH=s390x go build -o license-check-s390x --ldflags "-s -w" -a -installsuffix cgo

```