### PR TITLE
Ensure that relative vendor paths are skipped

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,11 +32,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	matchValidFile := func(path string) bool {
-		return strings.HasSuffix(path, ".go") &&
-			strings.Contains(path, "/vendor/") == false
-	}
-
 	licenseAudit := func(path string) bool {
 
 		if verbose {
@@ -101,4 +96,16 @@ func walk(rootPath string, passLicenseAudit func(string) bool, matchValidFile fu
 	})
 
 	return violations, err
+}
+
+func matchValidFile(path string) bool {
+	// capture cases where the path is relative and doesn't start with a slash,
+	// e.g. vendor/github.com/*
+	abspath, err := filepath.Abs(path)
+	if err != nil {
+		abspath = path
+	}
+
+	return strings.HasSuffix(abspath, ".go") &&
+		strings.Contains(abspath, "/vendor/") == false
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestFileMatch(t *testing.T) {
+
+	cases := []struct {
+		name  string
+		path  string
+		match bool
+	}{
+		{"go path matches", "teamserverlesss/foo/bar/utils.go", true},
+		{"non-go path does not match", "teamserverlesss/foo/bar/utils.py", false},
+		{"relative vendor path matches", "vendor/github.com/teamserverlesss/foo/bar/utils.go", false},
+		{"absolute vendor path matches", "/vendor/github.com/teamserverlesss/foo/bar/utils.go", false},
+		{"non-go path in vendor does not match", "/vendor/github.com/teamserverlesss/foo/bar/utils.yaml", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isMatch := matchValidFile(tc.path)
+			if isMatch != tc.match {
+				t.Errorf("expected %v, got %v for %s", tc.match, isMatch, tc.path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What**
- Update the file path matcher to handle cases where the vendor folder
was reported as a relative path