### PR TITLE
ppc64le support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,4 @@ COPY --from=builder /go/src/github.com/teamserverless/license-check/license-chec
 COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-armhf .
 COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-arm64 .
 COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-s390x .
+COPY --from=builder /go/src/github.com/teamserverless/license-check/license-check-ppc64le .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: linux darwin armhf arm64 s390x
+all: linux darwin armhf arm64 s390x ppc64le
 
 .PHONY: linux
 linux:
@@ -20,4 +20,8 @@ arm64:
 .PHONY: s390x
 s390x:
 	GOOS=linux GOARCH=s390x go build -o license-check-s390x --ldflags "-s -w" -a -installsuffix cgo
+
+.PHONY: ppc64le
+ppc64le:
+	GOOS=linux GOARCH=ppc64le go build -o license-check-ppc64le --ldflags "-s -w" -a -installsuffix cgo
 

--- a/get.sh
+++ b/get.sh
@@ -25,6 +25,11 @@ suffix="-darwin"
     suffix="s390x"
     ;;
     esac
+    case $arch in
+    "ppc64le")
+    suffix="-ppc64le"
+    ;;
+    esac
 ;;
 esac
 


### PR DESCRIPTION
Signed-off-by: Andrey Klyachkin <aklyachkin@gmail.com>

Support for Linux on ppc64le (IBM Power Systems, OpenPOWER)

## Description
Obbvious change to enable support for ppc64le

## Motivation and Context
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))

See https://github.com/teamserverless/license-check/issues/7

## Types of changes
- [ X ] New feature (non-breaking change which adds functionality)

## Checklist:
- [ X ] My code follows the code style of this project.
- [ - ] My change requires a change to the documentation.
- [ - ] I have updated the documentation accordingly.
- [ X ] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [ X ] I have signed-off my commits with `git commit -s`
- [ - ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
